### PR TITLE
Integration tests for Crypto SOL Coin Support and Unsupported Coin Transactions

### DIFF
--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1582,4 +1582,96 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
+  /**
+   * Test when a customer with no pre-existing Crypto buys ETH, buys SOL, and sells their SOL.
+   */
+  @Test
+  public void testCryptoBuyEthBuySolSellUserFlow() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+      .initialBalanceInDollars(1000)
+      .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+      .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction buyEth = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(900)
+      .expectedEndingCryptoBalance(0.1)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("ETH")
+      .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+      .shouldSucceed(true)
+      .build();
+    cryptoTransactionTester.test(buyEth);
+
+    CryptoTransaction buySol = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(800)
+      .expectedEndingCryptoBalance(0.1)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("SOL")
+      .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+      .shouldSucceed(true)
+      .build();
+    cryptoTransactionTester.test(buySol);
+
+    CryptoTransaction sellSol = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(900)
+      .expectedEndingCryptoBalance(0)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("SOL")
+      .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+      .shouldSucceed(true)
+      .build();
+    cryptoTransactionTester.test(sellSol);
+  }
+
+  /**
+   * Test that ensures that the "welcome" page is returned when a user attempts to put "BTC" 
+   * as the crypto name in the front-end when filling out the CryptoBuy form.
+   */
+  @Test
+  public void testCryptoBuyBtcInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+      .initialBalanceInDollars(1000)
+      .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction buyBtc = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(1000)
+      .expectedEndingCryptoBalance(0)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("BTC")
+      .shouldSucceed(false)
+      .build();
+    cryptoTransactionTester.test(buyBtc);
+  }
+
+  /**
+   * Test that ensures that the "welcome" page is returned when a user attempts to put "BTC" 
+   * as the crypto name in the front-end when filling out the CryptoSell form. 
+   */
+  @Test
+  public void testCryptoSellBtcInvalidCase() throws ScriptException {
+    CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
+      .initialBalanceInDollars(1000)
+      .build();
+
+    cryptoTransactionTester.initialize();
+
+    CryptoTransaction sellSol = CryptoTransaction.builder()
+      .expectedEndingBalanceInDollars(1000)
+      .expectedEndingCryptoBalance(0)
+      .cryptoPrice(1000)
+      .cryptoAmountToTransact(0.1)
+      .cryptoName("BTC")
+      .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+      .shouldSucceed(false)
+      .build();
+    cryptoTransactionTester.test(sellSol);
+  }
 }


### PR DESCRIPTION
**Changes Made in this PR:**
I created integration tests to check the support of SOL coin in the Testudobank Application. Also, the test makes sure that users are directed to the home page when they attempt a crypto transaction for an unsupported coin.

`src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`
- when a customer with no pre-existing Crypto buys ETH, buys SOL, and sells their SOL.
   - Ensures that SOL support is working and that customers can buy and sell SOL coins.
- when a user attempts to put "BTC" as the crypto name in the front-end when filling out the CryptoBuy form, return the "welcome" page.
   - Ensure that when customer attempt to buy unsupported coins like BTC, the transaction fails
- when a user attempts to put "BTC" as the crypto name in the front-end when filling out the CryptoSell form ensure that the "welcome" page is returned
   - Ensure that when customer attempt to sell unsupported coins like BTC, that the transaction fails